### PR TITLE
#2 - privatesky/modules/apihub/middlewares/stop-watch-logger/index.js…

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const START_TOKENS = 6000000;
 
 const CHECK_FOR_RESTART_COMMAND_FILE_INTERVAL = 500;
 
-const LoggerMiddleware = require('./middlewares/logger');
+const LoggerMiddleware = require('./middlewares/stop-watch-logger');
 const AuthorisationMiddleware = require('./middlewares/authorisation');
 const IframeHandlerMiddleware = require('./middlewares/iframeHandler');
 

--- a/middlewares/stop-watch-logger/index.js
+++ b/middlewares/stop-watch-logger/index.js
@@ -1,0 +1,17 @@
+function StopWatchLogger(server) {
+  console.log(`Registering StopWatchLogger middleware`);
+
+  server.use(function (req, res, next) {
+    let aStartDate = new Date();
+    let end = res.end;
+    res.end = function (...args) {
+			end.call(res, ...args);
+			let anEndDate = new Date();
+			console.log(`${anEndDate.toISOString()} [${req.method}] ${req.url} took ${anEndDate.getTime() - aStartDate.getTime()}ms.`);
+		}
+    console.log(`${aStartDate.toISOString()} [${req.method}] ${req.url} received.`);
+    next();
+  });
+}
+
+module.exports = StopWatchLogger;


### PR DESCRIPTION
OpenDSU Accell apihub better logging … based on @asaccool proposal of issue https://github.com/PrivateSky/apihub/issues/2

It is opinionated:

- has a timestamp prefix with resolution up to milisecond. (milisecond resolution is not enough in some other projects, where we have to link request/response with uuid - for example - but if in this case might be enough).
- makes no sense to keep both loggers (the original, and this one) turned on.