### PR TITLE
Fix notifications

### DIFF
--- a/components/keySsiNotifications/index.js
+++ b/components/keySsiNotifications/index.js
@@ -8,6 +8,8 @@ function KeySSINotifications(server) {
 	const path = require("path");
 	const storage = config.getConfig("storage");
 	const workingDirPath = path.join(storage, config.getConfig('endpointsConfig', 'messaging', 'workingDirPath'));
+	const storageDirPath = path.join(server.rootFolder, config.getConfig('endpointsConfig', 'messaging', 'storageDirPath'));
+    const QUEUED_MESSAGE_LIFETIME = 500; // (ms) Delete undelivered messages after this timeout
 
 	function publish(request, response) {
 		let anchorId = request.params.anchorId;
@@ -28,7 +30,7 @@ function KeySSINotifications(server) {
 					}
 				}
 
-				notificationManager.sendMessage(anchorId, message, function (err, counter) {
+				notificationManager.sendMessage(anchorId, message, QUEUED_MESSAGE_LIFETIME, function (err, counter) {
 					if (err) {
 						return response.send(500);
 					}

--- a/components/keySsiNotifications/index.js
+++ b/components/keySsiNotifications/index.js
@@ -8,7 +8,6 @@ function KeySSINotifications(server) {
 	const path = require("path");
 	const storage = config.getConfig("storage");
 	const workingDirPath = path.join(storage, config.getConfig('endpointsConfig', 'messaging', 'workingDirPath'));
-	const storageDirPath = path.join(server.rootFolder, config.getConfig('endpointsConfig', 'messaging', 'storageDirPath'));
     const QUEUED_MESSAGE_LIFETIME = 500; // (ms) Delete undelivered messages after this timeout
 
 	function publish(request, response) {


### PR DESCRIPTION
This PR introduces the following changes
- Bug fix for `NotificationsManager.createQueue()`
- Adds a "time to live" property to notifications messages together with a "cleanup" method
- Decreases the default message persistence timeout from 30secs to 500ms

Regarding the notifications TTL, the cleanup function iterates over all the queues and messages and removes any expired items. The current implementation is a quick fix, I'm planning to make the implementation async to prevent event loop hogging in case of lots of queues and undelivered notifications. I'm going with the quick fix version for now, because an OpenDSU notification test has already been merged in master, and will fail without this PR.

Regarding queued message persistence, the quickest fix is to lower the timeout.   
IMHO I would drop the timeout completely and persist the message right away if there are no subscribers. Worst case scenario (from a performance point of view) for lots of subscribers that connect to different queues after some messages have been published is the cost of writing & deleting the message files. For the time being I would say that this cost is negligible.

Another solution that would scale (performance wise) would be to run a separate thread that takes care of persisting any undelivered messages, this comes with the additional complexity of correctly handling server shutdown  - all undelivered messages need to be saved to disk before shutting down the server. Another drawback is that this solution doesn't guarantee to the publisher that the message has been indeed queued (in case of disk failures or unclean shutdown, messages could get lost).

@asaccool What are your thoughts on this?


